### PR TITLE
added missing closing } to ifl

### DIFF
--- a/snippets/language-ember-htmlbars.cson
+++ b/snippets/language-ember-htmlbars.cson
@@ -13,7 +13,7 @@
     'body': '{{action ${1:\'${2:name}\'}}}'
   'inline-if':
     'prefix': 'ifl'
-    'body': '{{if ${1:condition} \'${2:property}\'}'
+    'body': '{{if ${1:condition} \'${2:property}\'}}'
   'link-to':
     'prefix': 'lt'
     'body': '{{#link-to \'${1:route}\'}}\t$0{{/link-to}}'


### PR DESCRIPTION
Hi!

In the snippets/language-ember-htmlbars.cson file for the inline-if (ifl) one closing } was missing. I added it.

Thanks,
Nora
